### PR TITLE
fix: carditisサマリのデータを、詳しいワクチン名別に表示できるよう修正

### DIFF
--- a/_datasets/carditis-summary.json
+++ b/_datasets/carditis-summary.json
@@ -13,37 +13,42 @@
     "date": "2023/10/29",
     "issues_with_vaccine_name": [
       {
-        "vaccine_name": "コミナティ筋注",
-        "myocarditis_count": 336,
-        "pericarditis_count": 115
+        "vaccine_name": "コミナティRTU筋注(2価:起源株/オミクロン株BA.1)",
+        "myocarditis_count": 4,
+        "pericarditis_count": 3
+      },
+      {
+        "vaccine_name": "コミナティRTU筋注(2価:起源株/オミクロン株BA.4-5)",
+        "myocarditis_count": 20,
+        "pericarditis_count": 6
       },
       {
         "vaccine_name": "コミナティ筋注",
-        "myocarditis_count": 0,
-        "pericarditis_count": 0
+        "myocarditis_count": 312,
+        "pericarditis_count": 106
       },
       {
-        "vaccine_name": "コミナティ筋注5～11歳用",
+        "vaccine_name": "コミナティ筋注5~11歳用",
         "myocarditis_count": 7,
         "pericarditis_count": 2
       },
       {
-        "vaccine_name": "コミナティ筋注5～11歳用",
-        "myocarditis_count": 0,
-        "pericarditis_count": 0
-      },
-      {
-        "vaccine_name": "コミナティ筋注６ヵ月～４歳用",
-        "myocarditis_count": 0,
-        "pericarditis_count": 0
-      },
-      {
         "vaccine_name": "スパイクバックス筋注",
-        "myocarditis_count": 191,
+        "myocarditis_count": 189,
         "pericarditis_count": 42
       },
       {
-        "vaccine_name": "スパイクバックス筋注",
+        "vaccine_name": "スパイクバックス筋注(1価:オミクロン株XBB.1.5)",
+        "myocarditis_count": 1,
+        "pericarditis_count": 0
+      },
+      {
+        "vaccine_name": "スパイクバックス筋注(2価:起源株/オミクロン株BA.1)",
+        "myocarditis_count": 1,
+        "pericarditis_count": 0
+      },
+      {
+        "vaccine_name": "スパイクバックス筋注(2価:起源株/オミクロン株BA.4-5)",
         "myocarditis_count": 1,
         "pericarditis_count": 0
       },

--- a/carditis/metadata.yaml
+++ b/carditis/metadata.yaml
@@ -33,9 +33,6 @@
     expected_issues: [
       {
         file_name_prefix: '001198218',
-        vaccine_name: "コミナティ筋注",
-        myocarditis_count: 336,
-        pericarditis_count: 115,
         myocarditis: [
           {
             name: "コミナティ筋注",
@@ -67,9 +64,6 @@
       },
       {
         file_name_prefix: '001197010',
-        vaccine_name: "コミナティ筋注",
-        myocarditis_count: 0,
-        pericarditis_count: 0,
         myocarditis: [
           {
             name: "コミナティRTU筋注（1価：オミクロン株XBB.1.5）",
@@ -85,9 +79,6 @@
       },
       {
         file_name_prefix: '001198223',
-        vaccine_name: "スパイクバックス筋注",
-        myocarditis_count: 191,
-        pericarditis_count: 42,
         myocarditis: [
           {
             name: "スパイクバックス筋注",
@@ -119,9 +110,6 @@
       },
       {
         file_name_prefix: '001197011',
-        vaccine_name: "スパイクバックス筋注",
-        myocarditis_count: 1,
-        pericarditis_count: 0,
         myocarditis: [
           {
             name: "スパイクバックス筋注（1価:オミクロン株XBB.1.5）",
@@ -137,9 +125,6 @@
       },
       {
         file_name_prefix: '001197963',
-        vaccine_name: "ヌバキソビッド筋注",
-        myocarditis_count: 1,
-        pericarditis_count: 0,
         myocarditis: [
           {
             name: "ヌバキソビッド筋注",
@@ -156,9 +141,6 @@
       # 001197012 は上記と同じ内容なので抽出不要。
       {
         file_name_prefix: '001197964',
-        vaccine_name: "コミナティ筋注5～11歳用",
-        myocarditis_count: 7,
-        pericarditis_count: 2,
         myocarditis: [
           {
             name: "コミナティ筋注5～11歳用",
@@ -174,9 +156,6 @@
       },
       {
         file_name_prefix: '001197014',
-        vaccine_name: "コミナティ筋注5～11歳用",
-        myocarditis_count: 0,
-        pericarditis_count: 0,
         myocarditis: [
           {
             name: "コミナティ筋注5～11歳用（1価:オミクロン株XBB.1.5）",
@@ -192,9 +171,6 @@
       },
       {
         file_name_prefix: '001197467',
-        vaccine_name: "コミナティ筋注６ヵ月～４歳用",
-        myocarditis_count: 0,
-        pericarditis_count: 0,
         myocarditis: [
           {
             name: "コミナティ筋注6ヵ月～4歳用（1価:オミクロン株XBB.1.5）",

--- a/carditis/sum-carditis-summary-v1.py
+++ b/carditis/sum-carditis-summary-v1.py
@@ -1,4 +1,4 @@
-import json, os
+import json, os, unicodedata
 import yaml
 
 with open('metadata.yaml', "r", encoding='utf-8') as f:
@@ -6,22 +6,38 @@ with open('metadata.yaml', "r", encoding='utf-8') as f:
 metadata = metadata_root['metadata']
 expected_issues = metadata['expected_issues']
 
-carditis_issues = []
-myocarditis_list = []
-pericarditis_list = []
+
+myocarditis_dict = dict()
+pericarditis_dict = dict()
 for issue in expected_issues:
+    myocarditis_list = issue['myocarditis']
+    for item in myocarditis_list:
+        if item['count'] == 0:
+            continue
+        vaccine_name = unicodedata.normalize("NFKC", item['name'])
+        mVal = myocarditis_dict.get(vaccine_name, 0)
+        myocarditis_dict[vaccine_name] = mVal + item['count']
+
+    pericarditis_list = issue['pericarditis']
+    for item in pericarditis_list:
+        if item['count'] == 0:
+            continue
+        vaccine_name = unicodedata.normalize("NFKC", item['name'])
+        pVal = pericarditis_dict.get(vaccine_name, 0)
+        pericarditis_dict[vaccine_name] = pVal + item['count']
+
+carditis_issues = []
+for key in sorted(myocarditis_dict.keys()):
 	carditis_issues.append({
-        "vaccine_name": issue['vaccine_name'],
-        "myocarditis_count": issue['myocarditis_count'],
-        "pericarditis_count": issue['pericarditis_count']
+		"vaccine_name": key,
+		"myocarditis_count": myocarditis_dict.get(key, 0),
+		"pericarditis_count": pericarditis_dict.get(key, 0)
 	})
-	myocarditis_list.append(issue['myocarditis_count'])
-	pericarditis_list.append(issue['pericarditis_count'])
 
 sorted_issues = sorted(carditis_issues, key=lambda issue: issue['vaccine_name'])
 
-myocarditis_sum = sum(myocarditis_list)
-pericarditis_sum = sum(pericarditis_list)
+myocarditis_sum = sum(myocarditis_dict.values())
+pericarditis_sum = sum(pericarditis_dict.values())
 total_sum = sum([myocarditis_sum, pericarditis_sum])
 
 summary_data = {

--- a/carditis/verify-carditis-reports-v1.py
+++ b/carditis/verify-carditis-reports-v1.py
@@ -28,7 +28,7 @@ for issue in expected_issues:
 		expected_list = issue[dType]
 		total_count = 0
 		for item in expected_list:
-			item_name = unicodedata.normalize("NFKC",  item['name'])
+			item_name = unicodedata.normalize("NFKC", item['name'])
 			item_count = item['count']
 			if data_dict.get(item_name, 0) != item_count:
 				print(f'\033[33m[警告]\033[0m {item_name}: expected={item_count}, got={data_dict.get(item_name, 0)}')


### PR DESCRIPTION
## 問題点

現状は下図。

![image](https://github.com/vaccinesosjapan/dashboard-datasets/assets/147464913/0f508fce-97e0-4182-8e43-ee920606449b)

同じ名前のワクチン名（実は`XBB.1.5`のデータだったりして、もっと詳しいワクチン名で表示したいデータ）がグラフの凡例に並ぶなど、分かりにくい状態になってしまっている。

## 改善案

下図のように、詳しいワクチン名で凡例を示すと共に、小さい数字もわかりやすくするため表も示すようにする。

![image](https://github.com/vaccinesosjapan/dashboard-datasets/assets/147464913/95f89d58-7585-4ec4-8dbd-f55743e90ec3)
