### PR TITLE
認定比率などを算出する仕組みを追加

### DIFF
--- a/_datasets/judged-data.json
+++ b/_datasets/judged-data.json
@@ -1,0 +1,866 @@
+[
+  {
+    "Date": "2021/08/19",
+    "CertifiedCount": 29,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 29,
+    "RepudiationCountSum": 0,
+    "CertifiedRateSum": 100.0
+  },
+  {
+    "Date": "2021/09/13",
+    "CertifiedCount": 37,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 66,
+    "RepudiationCountSum": 0,
+    "CertifiedRateSum": 100.0
+  },
+  {
+    "Date": "2021/10/22",
+    "CertifiedCount": 80,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 146,
+    "RepudiationCountSum": 0,
+    "CertifiedRateSum": 100.0
+  },
+  {
+    "Date": "2021/11/19",
+    "CertifiedCount": 126,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 272,
+    "RepudiationCountSum": 0,
+    "CertifiedRateSum": 100.0
+  },
+  {
+    "Date": "2021/12/09",
+    "CertifiedCount": 17,
+    "RepudiationCount": 6,
+    "CertifiedRate": 73.91,
+    "CertifiedCountSum": 289,
+    "RepudiationCountSum": 6,
+    "CertifiedRateSum": 97.97
+  },
+  {
+    "Date": "2021/12/23",
+    "CertifiedCount": 110,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 399,
+    "RepudiationCountSum": 6,
+    "CertifiedRateSum": 98.52
+  },
+  {
+    "Date": "2022/01/28",
+    "CertifiedCount": 115,
+    "RepudiationCount": 3,
+    "CertifiedRate": 97.46,
+    "CertifiedCountSum": 514,
+    "RepudiationCountSum": 9,
+    "CertifiedRateSum": 98.28
+  },
+  {
+    "Date": "2022/02/10",
+    "CertifiedCount": 3,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 517,
+    "RepudiationCountSum": 9,
+    "CertifiedRateSum": 98.29
+  },
+  {
+    "Date": "2022/02/24",
+    "CertifiedCount": 48,
+    "RepudiationCount": 13,
+    "CertifiedRate": 78.69,
+    "CertifiedCountSum": 565,
+    "RepudiationCountSum": 22,
+    "CertifiedRateSum": 96.25
+  },
+  {
+    "Date": "2022/03/25",
+    "CertifiedCount": 84,
+    "RepudiationCount": 14,
+    "CertifiedRate": 85.71,
+    "CertifiedCountSum": 649,
+    "RepudiationCountSum": 36,
+    "CertifiedRateSum": 94.74
+  },
+  {
+    "Date": "2022/04/28",
+    "CertifiedCount": 58,
+    "RepudiationCount": 15,
+    "CertifiedRate": 79.45,
+    "CertifiedCountSum": 707,
+    "RepudiationCountSum": 51,
+    "CertifiedRateSum": 93.27
+  },
+  {
+    "Date": "2022/05/19",
+    "CertifiedCount": 23,
+    "RepudiationCount": 4,
+    "CertifiedRate": 85.19,
+    "CertifiedCountSum": 730,
+    "RepudiationCountSum": 55,
+    "CertifiedRateSum": 92.99
+  },
+  {
+    "Date": "2022/06/02",
+    "CertifiedCount": 62,
+    "RepudiationCount": 4,
+    "CertifiedRate": 93.94,
+    "CertifiedCountSum": 792,
+    "RepudiationCountSum": 59,
+    "CertifiedRateSum": 93.07
+  },
+  {
+    "Date": "2022/06/23",
+    "CertifiedCount": 56,
+    "RepudiationCount": 3,
+    "CertifiedRate": 94.92,
+    "CertifiedCountSum": 848,
+    "RepudiationCountSum": 62,
+    "CertifiedRateSum": 93.19
+  },
+  {
+    "Date": "2022/07/28",
+    "CertifiedCount": 60,
+    "RepudiationCount": 5,
+    "CertifiedRate": 92.31,
+    "CertifiedCountSum": 908,
+    "RepudiationCountSum": 67,
+    "CertifiedRateSum": 93.13
+  },
+  {
+    "Date": "2022/09/09",
+    "CertifiedCount": 10,
+    "RepudiationCount": 2,
+    "CertifiedRate": 83.33,
+    "CertifiedCountSum": 918,
+    "RepudiationCountSum": 69,
+    "CertifiedRateSum": 93.01
+  },
+  {
+    "Date": "2022/09/22",
+    "CertifiedCount": 65,
+    "RepudiationCount": 13,
+    "CertifiedRate": 83.33,
+    "CertifiedCountSum": 983,
+    "RepudiationCountSum": 82,
+    "CertifiedRateSum": 92.3
+  },
+  {
+    "Date": "2022/10/17",
+    "CertifiedCount": 11,
+    "RepudiationCount": 2,
+    "CertifiedRate": 84.62,
+    "CertifiedCountSum": 994,
+    "RepudiationCountSum": 84,
+    "CertifiedRateSum": 92.21
+  },
+  {
+    "Date": "2022/10/27",
+    "CertifiedCount": 101,
+    "RepudiationCount": 13,
+    "CertifiedRate": 88.6,
+    "CertifiedCountSum": 1095,
+    "RepudiationCountSum": 97,
+    "CertifiedRateSum": 91.86
+  },
+  {
+    "Date": "2022/11/07",
+    "CertifiedCount": 21,
+    "RepudiationCount": 4,
+    "CertifiedRate": 84.0,
+    "CertifiedCountSum": 1116,
+    "RepudiationCountSum": 101,
+    "CertifiedRateSum": 91.7
+  },
+  {
+    "Date": "2022/11/24",
+    "CertifiedCount": 111,
+    "RepudiationCount": 19,
+    "CertifiedRate": 85.38,
+    "CertifiedCountSum": 1227,
+    "RepudiationCountSum": 120,
+    "CertifiedRateSum": 91.09
+  },
+  {
+    "Date": "2022/12/12",
+    "CertifiedCount": 14,
+    "RepudiationCount": 5,
+    "CertifiedRate": 73.68,
+    "CertifiedCountSum": 1241,
+    "RepudiationCountSum": 125,
+    "CertifiedRateSum": 90.85
+  },
+  {
+    "Date": "2022/12/22",
+    "CertifiedCount": 70,
+    "RepudiationCount": 21,
+    "CertifiedRate": 76.92,
+    "CertifiedCountSum": 1311,
+    "RepudiationCountSum": 146,
+    "CertifiedRateSum": 89.98
+  },
+  {
+    "Date": "2023/01/12",
+    "CertifiedCount": 20,
+    "RepudiationCount": 1,
+    "CertifiedRate": 95.24,
+    "CertifiedCountSum": 1331,
+    "RepudiationCountSum": 147,
+    "CertifiedRateSum": 90.05
+  },
+  {
+    "Date": "2023/01/13",
+    "CertifiedCount": 64,
+    "RepudiationCount": 11,
+    "CertifiedRate": 85.33,
+    "CertifiedCountSum": 1395,
+    "RepudiationCountSum": 158,
+    "CertifiedRateSum": 89.83
+  },
+  {
+    "Date": "2023/01/23",
+    "CertifiedCount": 62,
+    "RepudiationCount": 8,
+    "CertifiedRate": 88.57,
+    "CertifiedCountSum": 1457,
+    "RepudiationCountSum": 166,
+    "CertifiedRateSum": 89.77
+  },
+  {
+    "Date": "2023/02/06",
+    "CertifiedCount": 79,
+    "RepudiationCount": 10,
+    "CertifiedRate": 88.76,
+    "CertifiedCountSum": 1536,
+    "RepudiationCountSum": 176,
+    "CertifiedRateSum": 89.72
+  },
+  {
+    "Date": "2023/02/09",
+    "CertifiedCount": 66,
+    "RepudiationCount": 11,
+    "CertifiedRate": 85.71,
+    "CertifiedCountSum": 1602,
+    "RepudiationCountSum": 187,
+    "CertifiedRateSum": 89.55
+  },
+  {
+    "Date": "2023/02/10",
+    "CertifiedCount": 18,
+    "RepudiationCount": 3,
+    "CertifiedRate": 85.71,
+    "CertifiedCountSum": 1620,
+    "RepudiationCountSum": 190,
+    "CertifiedRateSum": 89.5
+  },
+  {
+    "Date": "2023/03/14",
+    "CertifiedCount": 23,
+    "RepudiationCount": 1,
+    "CertifiedRate": 95.83,
+    "CertifiedCountSum": 1643,
+    "RepudiationCountSum": 191,
+    "CertifiedRateSum": 89.59
+  },
+  {
+    "Date": "2023/03/17",
+    "CertifiedCount": 184,
+    "RepudiationCount": 28,
+    "CertifiedRate": 86.79,
+    "CertifiedCountSum": 1827,
+    "RepudiationCountSum": 219,
+    "CertifiedRateSum": 89.3
+  },
+  {
+    "Date": "2023/03/27",
+    "CertifiedCount": 183,
+    "RepudiationCount": 23,
+    "CertifiedRate": 88.83,
+    "CertifiedCountSum": 2010,
+    "RepudiationCountSum": 242,
+    "CertifiedRateSum": 89.25
+  },
+  {
+    "Date": "2023/04/07",
+    "CertifiedCount": 176,
+    "RepudiationCount": 31,
+    "CertifiedRate": 85.02,
+    "CertifiedCountSum": 2186,
+    "RepudiationCountSum": 273,
+    "CertifiedRateSum": 88.9
+  },
+  {
+    "Date": "2023/04/17",
+    "CertifiedCount": 18,
+    "RepudiationCount": 3,
+    "CertifiedRate": 85.71,
+    "CertifiedCountSum": 2204,
+    "RepudiationCountSum": 276,
+    "CertifiedRateSum": 88.87
+  },
+  {
+    "Date": "2023/04/20",
+    "CertifiedCount": 192,
+    "RepudiationCount": 30,
+    "CertifiedRate": 86.49,
+    "CertifiedCountSum": 2396,
+    "RepudiationCountSum": 306,
+    "CertifiedRateSum": 88.68
+  },
+  {
+    "Date": "2023/05/08",
+    "CertifiedCount": 197,
+    "RepudiationCount": 40,
+    "CertifiedRate": 83.12,
+    "CertifiedCountSum": 2593,
+    "RepudiationCountSum": 346,
+    "CertifiedRateSum": 88.23
+  },
+  {
+    "Date": "2023/05/26",
+    "CertifiedCount": 27,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 2620,
+    "RepudiationCountSum": 346,
+    "CertifiedRateSum": 88.33
+  },
+  {
+    "Date": "2023/05/31",
+    "CertifiedCount": 17,
+    "RepudiationCount": 33,
+    "CertifiedRate": 34.0,
+    "CertifiedCountSum": 2637,
+    "RepudiationCountSum": 379,
+    "CertifiedRateSum": 87.43
+  },
+  {
+    "Date": "2023/06/09",
+    "CertifiedCount": 170,
+    "RepudiationCount": 19,
+    "CertifiedRate": 89.95,
+    "CertifiedCountSum": 2807,
+    "RepudiationCountSum": 398,
+    "CertifiedRateSum": 87.58
+  },
+  {
+    "Date": "2023/06/19",
+    "CertifiedCount": 23,
+    "RepudiationCount": 7,
+    "CertifiedRate": 76.67,
+    "CertifiedCountSum": 2830,
+    "RepudiationCountSum": 405,
+    "CertifiedRateSum": 87.48
+  },
+  {
+    "Date": "2023/06/26",
+    "CertifiedCount": 49,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 2879,
+    "RepudiationCountSum": 405,
+    "CertifiedRateSum": 87.67
+  },
+  {
+    "Date": "2023/06/29",
+    "CertifiedCount": 282,
+    "RepudiationCount": 13,
+    "CertifiedRate": 95.59,
+    "CertifiedCountSum": 3161,
+    "RepudiationCountSum": 418,
+    "CertifiedRateSum": 88.32
+  },
+  {
+    "Date": "2023/07/10",
+    "CertifiedCount": 172,
+    "RepudiationCount": 40,
+    "CertifiedRate": 81.13,
+    "CertifiedCountSum": 3333,
+    "RepudiationCountSum": 458,
+    "CertifiedRateSum": 87.92
+  },
+  {
+    "Date": "2023/07/14",
+    "CertifiedCount": 27,
+    "RepudiationCount": 9,
+    "CertifiedRate": 75.0,
+    "CertifiedCountSum": 3360,
+    "RepudiationCountSum": 467,
+    "CertifiedRateSum": 87.8
+  },
+  {
+    "Date": "2023/07/26",
+    "CertifiedCount": 172,
+    "RepudiationCount": 41,
+    "CertifiedRate": 80.75,
+    "CertifiedCountSum": 3532,
+    "RepudiationCountSum": 508,
+    "CertifiedRateSum": 87.43
+  },
+  {
+    "Date": "2023/07/31",
+    "CertifiedCount": 52,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 3584,
+    "RepudiationCountSum": 508,
+    "CertifiedRateSum": 87.59
+  },
+  {
+    "Date": "2023/08/04",
+    "CertifiedCount": 186,
+    "RepudiationCount": 41,
+    "CertifiedRate": 81.94,
+    "CertifiedCountSum": 3770,
+    "RepudiationCountSum": 549,
+    "CertifiedRateSum": 87.29
+  },
+  {
+    "Date": "2023/08/21",
+    "CertifiedCount": 38,
+    "RepudiationCount": 4,
+    "CertifiedRate": 90.48,
+    "CertifiedCountSum": 3808,
+    "RepudiationCountSum": 553,
+    "CertifiedRateSum": 87.32
+  },
+  {
+    "Date": "2023/08/30",
+    "CertifiedCount": 78,
+    "RepudiationCount": 0,
+    "CertifiedRate": 100.0,
+    "CertifiedCountSum": 3886,
+    "RepudiationCountSum": 553,
+    "CertifiedRateSum": 87.54
+  },
+  {
+    "Date": "2023/08/31",
+    "CertifiedCount": 210,
+    "RepudiationCount": 34,
+    "CertifiedRate": 86.07,
+    "CertifiedCountSum": 4096,
+    "RepudiationCountSum": 587,
+    "CertifiedRateSum": 87.47
+  },
+  {
+    "Date": "2023/09/11",
+    "CertifiedCount": 142,
+    "RepudiationCount": 1,
+    "CertifiedRate": 99.3,
+    "CertifiedCountSum": 4238,
+    "RepudiationCountSum": 588,
+    "CertifiedRateSum": 87.82
+  },
+  {
+    "Date": "2023/09/15",
+    "CertifiedCount": 36,
+    "RepudiationCount": 14,
+    "CertifiedRate": 72.0,
+    "CertifiedCountSum": 4274,
+    "RepudiationCountSum": 602,
+    "CertifiedRateSum": 87.65
+  },
+  {
+    "Date": "2023/09/22",
+    "CertifiedCount": 74,
+    "RepudiationCount": 3,
+    "CertifiedRate": 96.1,
+    "CertifiedCountSum": 4348,
+    "RepudiationCountSum": 605,
+    "CertifiedRateSum": 87.79
+  },
+  {
+    "Date": "2023/09/27",
+    "CertifiedCount": 170,
+    "RepudiationCount": 39,
+    "CertifiedRate": 81.34,
+    "CertifiedCountSum": 4518,
+    "RepudiationCountSum": 644,
+    "CertifiedRateSum": 87.52
+  },
+  {
+    "Date": "2023/10/06",
+    "CertifiedCount": 130,
+    "RepudiationCount": 35,
+    "CertifiedRate": 78.79,
+    "CertifiedCountSum": 4648,
+    "RepudiationCountSum": 679,
+    "CertifiedRateSum": 87.25
+  },
+  {
+    "Date": "2023/10/16",
+    "CertifiedCount": 25,
+    "RepudiationCount": 12,
+    "CertifiedRate": 67.57,
+    "CertifiedCountSum": 4673,
+    "RepudiationCountSum": 691,
+    "CertifiedRateSum": 87.12
+  },
+  {
+    "Date": "2023/10/23",
+    "CertifiedCount": 79,
+    "RepudiationCount": 16,
+    "CertifiedRate": 83.16,
+    "CertifiedCountSum": 4752,
+    "RepudiationCountSum": 707,
+    "CertifiedRateSum": 87.05
+  },
+  {
+    "Date": "2023/10/26",
+    "CertifiedCount": 160,
+    "RepudiationCount": 60,
+    "CertifiedRate": 72.73,
+    "CertifiedCountSum": 4912,
+    "RepudiationCountSum": 767,
+    "CertifiedRateSum": 86.49
+  },
+  {
+    "Date": "2023/11/13",
+    "CertifiedCount": 137,
+    "RepudiationCount": 19,
+    "CertifiedRate": 87.82,
+    "CertifiedCountSum": 5049,
+    "RepudiationCountSum": 786,
+    "CertifiedRateSum": 86.53
+  },
+  {
+    "Date": "2023/11/17",
+    "CertifiedCount": 36,
+    "RepudiationCount": 7,
+    "CertifiedRate": 83.72,
+    "CertifiedCountSum": 5085,
+    "RepudiationCountSum": 793,
+    "CertifiedRateSum": 86.51
+  },
+  {
+    "Date": "2023/11/24",
+    "CertifiedCount": 85,
+    "RepudiationCount": 34,
+    "CertifiedRate": 71.43,
+    "CertifiedCountSum": 5170,
+    "RepudiationCountSum": 827,
+    "CertifiedRateSum": 86.21
+  },
+  {
+    "Date": "2023/11/29",
+    "CertifiedCount": 185,
+    "RepudiationCount": 34,
+    "CertifiedRate": 84.47,
+    "CertifiedCountSum": 5355,
+    "RepudiationCountSum": 861,
+    "CertifiedRateSum": 86.15
+  },
+  {
+    "Date": "2023/12/08",
+    "CertifiedCount": 142,
+    "RepudiationCount": 21,
+    "CertifiedRate": 87.12,
+    "CertifiedCountSum": 5497,
+    "RepudiationCountSum": 882,
+    "CertifiedRateSum": 86.17
+  },
+  {
+    "Date": "2023/12/18",
+    "CertifiedCount": 27,
+    "RepudiationCount": 12,
+    "CertifiedRate": 69.23,
+    "CertifiedCountSum": 5524,
+    "RepudiationCountSum": 894,
+    "CertifiedRateSum": 86.07
+  },
+  {
+    "Date": "2023/12/25",
+    "CertifiedCount": 77,
+    "RepudiationCount": 30,
+    "CertifiedRate": 71.96,
+    "CertifiedCountSum": 5601,
+    "RepudiationCountSum": 924,
+    "CertifiedRateSum": 85.84
+  },
+  {
+    "Date": "2023/12/27",
+    "CertifiedCount": 132,
+    "RepudiationCount": 29,
+    "CertifiedRate": 81.99,
+    "CertifiedCountSum": 5733,
+    "RepudiationCountSum": 953,
+    "CertifiedRateSum": 85.75
+  },
+  {
+    "Date": "2024/01/15",
+    "CertifiedCount": 129,
+    "RepudiationCount": 29,
+    "CertifiedRate": 81.65,
+    "CertifiedCountSum": 5862,
+    "RepudiationCountSum": 982,
+    "CertifiedRateSum": 85.65
+  },
+  {
+    "Date": "2024/01/19",
+    "CertifiedCount": 27,
+    "RepudiationCount": 21,
+    "CertifiedRate": 56.25,
+    "CertifiedCountSum": 5889,
+    "RepudiationCountSum": 1003,
+    "CertifiedRateSum": 85.45
+  },
+  {
+    "Date": "2024/01/26",
+    "CertifiedCount": 74,
+    "RepudiationCount": 42,
+    "CertifiedRate": 63.79,
+    "CertifiedCountSum": 5963,
+    "RepudiationCountSum": 1045,
+    "CertifiedRateSum": 85.09
+  },
+  {
+    "Date": "2024/01/31",
+    "CertifiedCount": 123,
+    "RepudiationCount": 46,
+    "CertifiedRate": 72.78,
+    "CertifiedCountSum": 6086,
+    "RepudiationCountSum": 1091,
+    "CertifiedRateSum": 84.8
+  },
+  {
+    "Date": "2024/02/09",
+    "CertifiedCount": 156,
+    "RepudiationCount": 35,
+    "CertifiedRate": 81.68,
+    "CertifiedCountSum": 6242,
+    "RepudiationCountSum": 1126,
+    "CertifiedRateSum": 84.72
+  },
+  {
+    "Date": "2024/02/19",
+    "CertifiedCount": 32,
+    "RepudiationCount": 21,
+    "CertifiedRate": 60.38,
+    "CertifiedCountSum": 6274,
+    "RepudiationCountSum": 1147,
+    "CertifiedRateSum": 84.54
+  },
+  {
+    "Date": "2024/02/26",
+    "CertifiedCount": 68,
+    "RepudiationCount": 55,
+    "CertifiedRate": 55.28,
+    "CertifiedCountSum": 6342,
+    "RepudiationCountSum": 1202,
+    "CertifiedRateSum": 84.07
+  },
+  {
+    "Date": "2024/02/29",
+    "CertifiedCount": 127,
+    "RepudiationCount": 65,
+    "CertifiedRate": 66.15,
+    "CertifiedCountSum": 6469,
+    "RepudiationCountSum": 1267,
+    "CertifiedRateSum": 83.62
+  },
+  {
+    "Date": "2024/03/11",
+    "CertifiedCount": 110,
+    "RepudiationCount": 51,
+    "CertifiedRate": 68.32,
+    "CertifiedCountSum": 6579,
+    "RepudiationCountSum": 1318,
+    "CertifiedRateSum": 83.31
+  },
+  {
+    "Date": "2024/03/15",
+    "CertifiedCount": 17,
+    "RepudiationCount": 27,
+    "CertifiedRate": 38.64,
+    "CertifiedCountSum": 6596,
+    "RepudiationCountSum": 1345,
+    "CertifiedRateSum": 83.06
+  },
+  {
+    "Date": "2024/03/18",
+    "CertifiedCount": 52,
+    "RepudiationCount": 51,
+    "CertifiedRate": 50.49,
+    "CertifiedCountSum": 6648,
+    "RepudiationCountSum": 1396,
+    "CertifiedRateSum": 82.65
+  },
+  {
+    "Date": "2024/03/28",
+    "CertifiedCount": 145,
+    "RepudiationCount": 52,
+    "CertifiedRate": 73.6,
+    "CertifiedCountSum": 6793,
+    "RepudiationCountSum": 1448,
+    "CertifiedRateSum": 82.43
+  },
+  {
+    "Date": "2024/04/12",
+    "CertifiedCount": 119,
+    "RepudiationCount": 41,
+    "CertifiedRate": 74.38,
+    "CertifiedCountSum": 6912,
+    "RepudiationCountSum": 1489,
+    "CertifiedRateSum": 82.28
+  },
+  {
+    "Date": "2024/04/17",
+    "CertifiedCount": 74,
+    "RepudiationCount": 38,
+    "CertifiedRate": 66.07,
+    "CertifiedCountSum": 6986,
+    "RepudiationCountSum": 1527,
+    "CertifiedRateSum": 82.06
+  },
+  {
+    "Date": "2024/04/25",
+    "CertifiedCount": 129,
+    "RepudiationCount": 49,
+    "CertifiedRate": 72.47,
+    "CertifiedCountSum": 7115,
+    "RepudiationCountSum": 1576,
+    "CertifiedRateSum": 81.87
+  },
+  {
+    "Date": "2024/05/02",
+    "CertifiedCount": 27,
+    "RepudiationCount": 28,
+    "CertifiedRate": 49.09,
+    "CertifiedCountSum": 7142,
+    "RepudiationCountSum": 1604,
+    "CertifiedRateSum": 81.66
+  },
+  {
+    "Date": "2024/05/13",
+    "CertifiedCount": 86,
+    "RepudiationCount": 70,
+    "CertifiedRate": 55.13,
+    "CertifiedCountSum": 7228,
+    "RepudiationCountSum": 1674,
+    "CertifiedRateSum": 81.2
+  },
+  {
+    "Date": "2024/05/17",
+    "CertifiedCount": 75,
+    "RepudiationCount": 39,
+    "CertifiedRate": 65.79,
+    "CertifiedCountSum": 7303,
+    "RepudiationCountSum": 1713,
+    "CertifiedRateSum": 81.0
+  },
+  {
+    "Date": "2024/05/20",
+    "CertifiedCount": 49,
+    "RepudiationCount": 34,
+    "CertifiedRate": 59.04,
+    "CertifiedCountSum": 7352,
+    "RepudiationCountSum": 1747,
+    "CertifiedRateSum": 80.8
+  },
+  {
+    "Date": "2024/05/31",
+    "CertifiedCount": 30,
+    "RepudiationCount": 22,
+    "CertifiedRate": 57.69,
+    "CertifiedCountSum": 7382,
+    "RepudiationCountSum": 1769,
+    "CertifiedRateSum": 80.67
+  },
+  {
+    "Date": "2024/06/10",
+    "CertifiedCount": 74,
+    "RepudiationCount": 27,
+    "CertifiedRate": 73.27,
+    "CertifiedCountSum": 7456,
+    "RepudiationCountSum": 1796,
+    "CertifiedRateSum": 80.59
+  },
+  {
+    "Date": "2024/06/17",
+    "CertifiedCount": 46,
+    "RepudiationCount": 58,
+    "CertifiedRate": 44.23,
+    "CertifiedCountSum": 7502,
+    "RepudiationCountSum": 1854,
+    "CertifiedRateSum": 80.18
+  },
+  {
+    "Date": "2024/06/20",
+    "CertifiedCount": 46,
+    "RepudiationCount": 58,
+    "CertifiedRate": 44.23,
+    "CertifiedCountSum": 7548,
+    "RepudiationCountSum": 1912,
+    "CertifiedRateSum": 79.79
+  },
+  {
+    "Date": "2024/06/28",
+    "CertifiedCount": 25,
+    "RepudiationCount": 33,
+    "CertifiedRate": 43.1,
+    "CertifiedCountSum": 7573,
+    "RepudiationCountSum": 1945,
+    "CertifiedRateSum": 79.57
+  },
+  {
+    "Date": "2024/07/05",
+    "CertifiedCount": 63,
+    "RepudiationCount": 59,
+    "CertifiedRate": 51.64,
+    "CertifiedCountSum": 7636,
+    "RepudiationCountSum": 2004,
+    "CertifiedRateSum": 79.21
+  },
+  {
+    "Date": "2024/07/11",
+    "CertifiedCount": 53,
+    "RepudiationCount": 51,
+    "CertifiedRate": 50.96,
+    "CertifiedCountSum": 7689,
+    "RepudiationCountSum": 2055,
+    "CertifiedRateSum": 78.91
+  },
+  {
+    "Date": "2024/07/25",
+    "CertifiedCount": 24,
+    "RepudiationCount": 33,
+    "CertifiedRate": 42.11,
+    "CertifiedCountSum": 7713,
+    "RepudiationCountSum": 2088,
+    "CertifiedRateSum": 78.7
+  },
+  {
+    "Date": "2024/07/31",
+    "CertifiedCount": 73,
+    "RepudiationCount": 32,
+    "CertifiedRate": 69.52,
+    "CertifiedCountSum": 7786,
+    "RepudiationCountSum": 2120,
+    "CertifiedRateSum": 78.6
+  },
+  {
+    "Date": "2024/08/05",
+    "CertifiedCount": 64,
+    "RepudiationCount": 35,
+    "CertifiedRate": 64.65,
+    "CertifiedCountSum": 7850,
+    "RepudiationCountSum": 2155,
+    "CertifiedRateSum": 78.46
+  },
+  {
+    "Date": "2024/08/19",
+    "CertifiedCount": 38,
+    "RepudiationCount": 62,
+    "CertifiedRate": 38.0,
+    "CertifiedCountSum": 7888,
+    "RepudiationCountSum": 2217,
+    "CertifiedRateSum": 78.06
+  }
+]

--- a/certified/README.md
+++ b/certified/README.md
@@ -58,3 +58,11 @@ python sum-certified-reports-v1.py
 ```sh
 python sum-trends.py
 ```
+
+## 審議結果の総数や認定比率を算出する
+
+毎回の認定/否認の件数や認定比率、累計の認定/否認の件数や認定比率を算出してデータファイルに保存します。
+
+```sh
+python sum-judged-data.py
+```

--- a/certified/sum-judged-data.py
+++ b/certified/sum-judged-data.py
@@ -1,0 +1,45 @@
+import json, os
+import yaml
+import pandas as pd
+
+output_dir = '../_datasets'
+
+with open('reports-settings-all.yaml', "r", encoding='utf-8') as file:
+    settings_root = yaml.safe_load(file)
+settings = settings_root['settings']
+
+date_list = []
+certified_list = []
+repudiation_list = []
+
+for setting in settings:
+    date_list.append(setting['date'])
+    certified_list.append(setting['expected_count']['certified'])
+    repudiation_list.append(setting['expected_count']['repudiation'])
+
+df = pd.DataFrame({'Date': date_list, 'CertifiedCount': certified_list, 'RepudiationCount': repudiation_list})
+df['CertifiedRate'] = round(df['CertifiedCount'] / (df['CertifiedCount'] + df['RepudiationCount']) * 100, 2)
+df['CertifiedCountSum'] = df['CertifiedCount'].cumsum()
+df['RepudiationCountSum'] = df['RepudiationCount'].cumsum()
+df['CertifiedRateSum'] = round( df['CertifiedCountSum'] / (df['CertifiedCountSum'] + df['RepudiationCountSum']) * 100, 2 )
+
+data_list = []
+rowCount = df.shape[0]
+for rowIndex in range(0, rowCount):
+	row = df.loc[rowIndex]
+	data_list.append({
+		'Date': row['Date'],
+		'CertifiedCount': row['CertifiedCount'].item(),
+		'RepudiationCount': row['RepudiationCount'].item(),
+		'CertifiedRate': row['CertifiedRate'],
+		'CertifiedCountSum': row['CertifiedCountSum'].item(),
+		'RepudiationCountSum': row['RepudiationCountSum'].item(),
+		'CertifiedRateSum': row['CertifiedRateSum']
+	})
+
+output_file_path = os.path.join(output_dir, 'judged-data.json')
+json_string = json.dumps(data_list, ensure_ascii=False, indent=2)
+with open(output_file_path, "w", encoding='utf-8') as f:
+	f.write(json_string)
+
+

--- a/medical-institution/README.md
+++ b/medical-institution/README.md
@@ -9,3 +9,12 @@
 * `lot_no`は文字列にすること（"lot_no":9999）というように数字として記載してしまうと、フロントエンド側が内部でエラー起こす。
   * これについてフロントエンド側でタイプチェックしてエラーが起きないようにするという処置も考えられたが、パフォーマンスが著しく低下するためデータを修正するようにした。
   * 問題箇所の有無をチェックするには、VSCodeなどの検索ツールで正規表現をOnにして「"lot_no": [^" ]」や「"lot_no":[^" ]」を検索すればよい。
+
+## 手順
+
+1. 新しいPDFを`pdf-files`フォルダにダウンロードする
+1. ダウンロードしたPDFのファイル名やリンクURLなどを`reports-settings.yaml`に記入する
+1. `create-medial-institution-reports-v1.py`を実行する
+1. エラーなく処理が完了したら、`reports-settings.yaml`の内容を`reports-settings-all.yaml`の末尾に追記する
+1. PDFから読み取った日付などを`summary-metadata.yaml`に記入する
+1. `sum-medical-institution-reports-v1.py`を実行する


### PR DESCRIPTION
[ダッシュボード側のIssue #38](https://github.com/vaccinesosjapan/dashboard/issues/38) で使うデータを生成する改善。